### PR TITLE
Gemspec can get the current gem version.

### DIFF
--- a/apartment-activejob.gemspec
+++ b/apartment-activejob.gemspec
@@ -1,11 +1,11 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'activejob/version'
+require 'apartment/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "apartment-activejob"
-  spec.version       = Apartment::Activejob::VERSION
+  spec.version       = Apartment::ActiveJob::VERSION
   spec.authors       = ["Zulfiqar Ali"]
   spec.email         = ["zulfiqar@influitive.com"]
   spec.summary       = %q{ActiveJob support for Apartment}

--- a/lib/apartment/version.rb
+++ b/lib/apartment/version.rb
@@ -1,5 +1,5 @@
 module Apartment
-  module Activejob
+  module ActiveJob
     VERSION = "0.0.1"
   end
 end


### PR DESCRIPTION
Gem spec can properly load the version so that this gem can be installed via bundler.
