### PR TITLE
Switch to the public tenant when enqueueing

### DIFF
--- a/lib/apartment/active_job.rb
+++ b/lib/apartment/active_job.rb
@@ -10,8 +10,19 @@ module Apartment
       end
     end
 
+    def initialize(*arguments)
+      @tenant = Apartment::Tenant.current
+      super(*arguments)
+    end
+
+    def enqueue(*arguments)
+      Apartment::Tenant.switch('public') do
+        super(*arguments)
+      end
+    end
+
     def serialize
-      super.merge('tenant' => Apartment::Tenant.current)
+      super.merge('tenant' => @tenant)
     end
   end
 end


### PR DESCRIPTION
At least in the case of [Que](https://github.com/chanks/que), jobs will only be worked when on the public tenant.

This makes it so jobs are enqueued on the public tenant, then switched to the current tenant when worked.